### PR TITLE
Added dependency injection for Structured Logger in NestJSInitial commit to use logger as injection

### DIFF
--- a/src/structured-logging.module.ts
+++ b/src/structured-logging.module.ts
@@ -7,6 +7,7 @@ import { ElasticsearchTransport, ElasticsearchTransportOptions } from 'winston-e
 import { simple } from './simple.format';
 import { Global, Module } from '@nestjs/common';
 import { StructuredLoggerFactory } from './structured-logger.factory';
+import { prefixesForLoggers, StructuredLogger } from './structured.logger';
 
 export type ServiceInfo = {
   region?: string;
@@ -112,5 +113,22 @@ export class StructuredLoggingModule {
     const logger = new WinstonLoggerService(loggerOptions);
 
     return logger;
+  }
+
+  static forRoot(): DynamicModule {
+    const providers = [...prefixesForLoggers].map(prefix => {
+      return {
+        provide: `StructuredLogger$${prefix.name}`,
+        useFactory: () => {
+          return new StructuredLogger(prefix.name);
+        }
+      }
+    });
+
+    return {
+      module: StructuredLoggingModule,
+      providers: providers,
+      exports: providers,
+    };
   }
 }

--- a/src/structured.logger.ts
+++ b/src/structured.logger.ts
@@ -125,14 +125,14 @@ export class StructuredLogger {
   }
 }
 
-export type ObjectType<T> = | { new (): T; } | Function;
+export const prefixesForLoggers = new Set<Function>();
 
-export class TypedStructuredLogger<Service> extends StructuredLogger {
-  constructor(target: ObjectType<Service>) {
-    super(target.name);
-  }
-}
+export type ObjectType<T> = | { new(): T; } | Function;
 
 export const InjectLogger = (
   entity: Function
-): ReturnType<typeof Inject> => Inject(new TypedStructuredLogger(entity));
+): ReturnType<typeof Inject> => {
+  prefixesForLoggers.add(entity);
+
+  return Inject(`StructuredLogger$${entity.name}`);
+};

--- a/src/structured.logger.ts
+++ b/src/structured.logger.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { Inject, Logger } from '@nestjs/common';
 
 // eslint-disable-next-line no-useless-escape
 const PLACEHOLDER_REGEX = /\$\{([^\}\$\{]+)\}/g;
@@ -124,3 +124,15 @@ export class StructuredLogger {
     return { ...data, message: messageStr };
   }
 }
+
+export type ObjectType<T> = | { new (): T; } | Function;
+
+export class TypedStructuredLogger<Service> extends StructuredLogger {
+  constructor(target: ObjectType<Service>) {
+    super(target.name);
+  }
+}
+
+export const InjectLogger = (
+  entity: Function
+): ReturnType<typeof Inject> => Inject(new TypedStructuredLogger(entity));


### PR DESCRIPTION
## Description:
This PR implements dependency injection for structured logger in the NestJS framework, allowing greater flexibility and customization in the use of the logger in different parts of the application.

## Changes:
Creation of a provider for the structured logger that facilitates injection into services and controllers.

## Motivation:
Previously, the logger was implemented directly, making it difficult to customize and mock logger at jest. With dependency injection, the framework becomes more modular and aligned with NestJS best practices, such as inversion of control.

## Additional notes:
This change should not impact other areas of the code, as logger injection is configured independently and optionally.

![image](https://github.com/user-attachments/assets/14963bd8-0068-45dc-9572-8d34549d541d)
