### PR TITLE
Adjustment to use InjectLogger without any parameters

### DIFF
--- a/src/structured.logger.ts
+++ b/src/structured.logger.ts
@@ -125,10 +125,11 @@ export class StructuredLogger {
   }
 }
 
-export const prefixesForLoggers = new Set<() => void>();
+export const prefixesForLoggers = new Set<Function>();
 
-export const InjectLogger = (entity: () => void): ReturnType<typeof Inject> => {
-  prefixesForLoggers.add(entity);
-
-  return Inject(`StructuredLogger$${entity.name}`);
+export const InjectLogger = (): ReturnType<typeof Inject> => {
+  return (target: Function, key: string | symbol, index?: number) => {
+    prefixesForLoggers.add(target);
+    return Inject(`StructuredLogger$${target.name}`)(target, key, index);
+  };
 };


### PR DESCRIPTION
# Description

This pull request changes the `InjectLogger` annotation to not require any parameters to figure out the name of the class it refers to.

![image](https://github.com/user-attachments/assets/333ebc3e-1ced-454d-b958-2cdc7418568c)
